### PR TITLE
Add "(passed)" to passed songs in /show_all_songs

### DIFF
--- a/worlds/osu/Client.py
+++ b/worlds/osu/Client.py
@@ -98,7 +98,8 @@ class APosuClientCommandProcessor(ClientCommandProcessor):
         """Displays all songs included in current generation."""
         for song in self.ctx.pairs:
             beatmapset = self.ctx.pairs[song]
-            self.output(f"{song}: {beatmapset['title']} (ID: {beatmapset['id']})")
+            has_played = song not in self.ctx.missing_locations
+            self.output(f"{song}: {beatmapset['title']} (ID: {beatmapset['id']}) {'(passed)' if has_played else ''}")
 
     def _cmd_get_last_scores(self, mode=''):
         """Gets the player's last score, in a given gamemode or their set default"""

--- a/worlds/osu/Client.py
+++ b/worlds/osu/Client.py
@@ -96,10 +96,10 @@ class APosuClientCommandProcessor(ClientCommandProcessor):
 
     def _cmd_show_all_songs(self):
         """Displays all songs included in current generation."""
+        played_songs = self.get_played_songs()
         for song in self.ctx.pairs:
             beatmapset = self.ctx.pairs[song]
-            has_played = song not in self.ctx.missing_locations
-            self.output(f"{song}: {beatmapset['title']} (ID: {beatmapset['id']}) {'(passed)' if has_played else ''}")
+            self.output(f"{song}: {beatmapset['title']} (ID: {beatmapset['id']}) {'(passed)' if song in played_songs else ''}")
 
     def _cmd_get_last_scores(self, mode=''):
         """Gets the player's last score, in a given gamemode or their set default"""
@@ -183,6 +183,25 @@ class APosuClientCommandProcessor(ClientCommandProcessor):
             incomplete_items.append(-1)
         incomplete_items.sort()
         return incomplete_items
+
+    def get_played_ids(self):
+        # Gets the Index of each Song the player has played
+        played_items = []
+        for item in self.ctx.items_received:
+            song_index = item.item-727000000
+            location_id = (song_index*2)+727000000
+            if location_id not in self.ctx.missing_locations and location_id+1 not in self.ctx.missing_locations:
+                played_items.append(song_index)
+        played_items.sort()
+        return played_items
+    
+    def get_played_songs(self):
+        # Gets the Song value of each Song the player has played
+        played_ids = self.get_played_ids()
+        played_songs = []
+        for played in played_ids:
+            played_songs.append(list(self.ctx.pairs.keys())[played])
+        return played_songs
 
     def check_location(self, score):
         self.output(score['beatmapset']['title'] + " " + score['beatmap']['version'] + f' Passed: {score["passed"]}')


### PR DESCRIPTION
## What is this fixing or adding?
When you have played a song, it will show "(passed)" next to it when running /show_all_songs
This feature was on a TODO list someone idk

## How was this tested?
Local instance of server and client with lots of trial and error

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/lilymnky-F/Archipelago-Osu/assets/9339576/83aa2799-829a-4b83-a4e6-72b00c9cf429)