### PR TITLE
Fix broken downloader

### DIFF
--- a/worlds/osu/Client.py
+++ b/worlds/osu/Client.py
@@ -296,11 +296,17 @@ class APosuClientCommandProcessor(ClientCommandProcessor):
             return
         f = f'{beatmapset["id"]} {beatmapset["artist"]} - {beatmapset["title"]}.osz'
         filename = "".join(i for i in f if i not in "\/:*?<>|\"")
-        path = self.ctx.game_communication_path + ' config'
-        with open(os.path.join(path, filename), 'wb') as f:
+        path = os.path.join(self.ctx.game_communication_path, 'config')
+        
+        if not os.path.exists(path):
+            os.makedirs(path)
+        
+        file_path = os.path.join(path, filename)
+        with open(file_path, 'wb') as f:
             f.write(content)
+        
         self.output(f'Opening {filename}...') # More feedback to the user
-        webbrowser.open(os.path.join(path, filename))
+        webbrowser.open(file_path)
 
 
 class APosuContext(CommonContext):


### PR DESCRIPTION
## What is this fixing or adding?
I haven't been doing AP osu lately and when I decided to try it again, the downloader broke.
Here is what I wrote on Discord:
Apparently downloader broke (got stuck on the `with open(os.path.join(path, filename), 'wb') as f:` function and never actually got anywhere) for me and my friend, so I made this PR to fix it, please check if it works both before and after for you

## How was this tested?
/download next
![image](https://github.com/lilymnky-F/Archipelago-Osu/assets/9339576/29a904ac-79ec-447a-9ffd-2d4337e9f56b)
Test with debug prints that are not in this PR because they are debug prints

## If this makes graphical changes, please attach screenshots.
