### PR TITLE
Made /update async and able to download next song

### DIFF
--- a/worlds/osu/Client.py
+++ b/worlds/osu/Client.py
@@ -565,11 +565,11 @@ async def get_last_scores(self, mode=''):
     try:
         request = f"https://osu.ppy.sh/api/v2/users/{os.environ['PLAYER_ID']}/scores/recent?include_fails=1&limit=100"
     except KeyError:
-        self.output('No Player ID')
+        self.output('Set a Player ID')
         return
     # Add Mode to request, otherwise it will use the user's default
-    if mode:
-        request += f"&mode={mode}"
+    if mode and mode.lower() in self.mode_names.keys():
+        request += f"&mode={self.mode_names[mode.lower()]}"
     if not self.ctx.token:
         await get_token(self.ctx)
     headers = {"Accept": "application/json", "Content-Type": "application/json", "Authorization": f"Bearer {self.ctx.token}"}

--- a/worlds/osu/Client.py
+++ b/worlds/osu/Client.py
@@ -105,11 +105,10 @@ class APosuClientCommandProcessor(ClientCommandProcessor):
         for song in self.ctx.pairs:
             beatmapset = self.ctx.pairs[song]
             self.output(f"{song}: {beatmapset['title']} (ID: {beatmapset['id']}) {'(passed)' if song in played_songs else ''}")
-    
+
     def _cmd_update(self, mode=''):
         """Gets the player's last score, in a given gamemode or their set default"""
         asyncio.create_task(get_last_scores(self, mode))
-        
 
     def _cmd_download(self, number=''):
         """Downloads the given song number in '/songs'. Also Accepts "Next" and "Victory"."""
@@ -455,7 +454,7 @@ async def open_set_in_direct(ctx, set_id: int) -> None:
         print(beatmapset)
     webbrowser.open(f"osu://b/{beatmapset['beatmaps'][0]['id']}")
 
-
+# This is the silent version of the function below where this one is used in game watcher
 async def download_next_beatmapset_silent(ctx, task):
     await task
     await asyncio.sleep(0.2)  # Delay to get the reply
@@ -488,6 +487,7 @@ async def download_next_beatmapset_silent(ctx, task):
     except Exception as e:
         print(f"An error occurred: {e}")
 
+# This is the non-silent version of the function above where this one is used in the update command
 async def download_next_beatmapset(self, task):
     await task
     await asyncio.sleep(0.2)  # Delay to get the reply
@@ -521,7 +521,7 @@ async def download_next_beatmapset(self, task):
     except Exception as e:
         self.output(f"An error occurred: {e}")
 
-
+# This is the silent version of the function below where this one is used in game watcher
 async def auto_get_last_scores(ctx, mode=''):
     # Make URl for the request
     try:
@@ -559,6 +559,7 @@ async def auto_get_last_scores(ctx, mode=''):
             ctx.last_scores.pop(0)
         check_location(ctx, score)
 
+# This is the non-silent version of the function above where this one is used in the update command
 async def get_last_scores(self, mode=''):
     # Make URl for the request
     try:


### PR DESCRIPTION
## What is this fixing or adding?
It is changing /update to be async and download next song if auto download is true
It essentially just invoking a slightly modified version of the code used for game watcher, please see for yourself

## How was this tested?
Through blood sweat and tears with lots of trial and error on a local AP server instance
I should have read the existing code and just invoked that instead of trying (and failing) to recreate what already exists, but you live and learn

**Please test this too to make sure it works properly as it felt like I changed alot**

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/lilymnky-F/Archipelago-Osu/assets/9339576/a4ca8d6a-0a52-401b-b9ae-d047c4d6f10c)
