### PR TITLE
More Strict Grade prep work and Feedback Addressing

### DIFF
--- a/worlds/osu/Client.py
+++ b/worlds/osu/Client.py
@@ -627,7 +627,7 @@ def calculate_grade(score):
     # if the score has 100% accuracy, then it is an SS no matter gamemode or grading system
     # skip the rest of the checks
     if acc == 1:
-        return 'SS'
+        return 'X'
 
     # if this score has the Classic mod enabled or if it has a legacy id, then we assume it is a stable score
     elif any(mod['acronym'] == 'CL' for mod in score['mods']) or score['legacy_score_id']:
@@ -667,7 +667,7 @@ def calculate_grade(score):
             return 'D'
     # if it is a lazer score, then the API did all the work for us
     else:
-        return score['rank']
+        return score['rank'].replace('XH', 'X').replace('SH', 'S') # remove hidden and flashlight from the grade
            
            
 def get_played_ids(ctx):

--- a/worlds/osu/Client.py
+++ b/worlds/osu/Client.py
@@ -668,7 +668,12 @@ def calculate_grade(score):
     # if it is a lazer score, then the API did all the work for us
     else:
         return score['rank'].replace('XH', 'X').replace('SH', 'S') # remove hidden and flashlight from the grade
-           
+
+# compares two grades and returns the difference between them
+# the difference is positive if grade1 is better than grade2
+def compare_grades(grade1, grade2):
+    grades = ['X', 'S', 'A', 'B', 'C', 'D']
+    return grades.index(grade1) - grades.index(grade2)
            
 def get_played_ids(ctx):
     # Gets the Index of each Song the player has played

--- a/worlds/osu/Options.py
+++ b/worlds/osu/Options.py
@@ -225,7 +225,7 @@ class PerformancePointsWinCountPercentage(Range):
 
 
 class IncludeSongs(OptionSet):
-    """List of Beatmapset IDs to include. Will add songs in ascending order by ID after the starting songs.
+    """List of Beatmapset IDs to include, each replacing a Rando song. Will add songs in ascending order by ID after the starting songs.
     IE: If you have 5 starting songs, the first ID will be song 6.
     """
     display_name = "Include Songs"


### PR DESCRIPTION
## What is this fixing or adding?
Changed Calculate grade to use the X for SS and removed the H from hidden/flashlight scores
Someone said that the include songs list had a bit confusing wording where it sounded like it was necessary to fill out the include songs list
Made a function that can compare grades. This can be used to check if a grade is sufficient for whenever strict grade is made

## How was this tested?
API said X and included the H

## If this makes graphical changes, please attach screenshots.
