### PR TITLE
Client: Fixed "Missing SSL Certification" Error & "Couldn't detect system type" Error on Linux

### DIFF
--- a/worlds/osu/requirements.txt
+++ b/worlds/osu/requirements.txt
@@ -1,2 +1,3 @@
 orjson>=3.9.10
 requests~=2.31.0
+certifi>=2024.6.2


### PR DESCRIPTION
Uses the "certifi" pip package to avoid errors with missing SSL certificate file
This is done by adding a ClientSession wrapper with "certifi" ssl certification around aiohttp requests

Uses the "platform" import to check system type and set the "game_communication_path" variable to the Linux & Mac equivalents of local appdata

Tested on an EndevourOS arch-linux system, with a KDE-Plasma environment